### PR TITLE
fix wrong 'intermediate_size' issue for baichuan2-13b

### DIFF
--- a/model_zoo/baichuan/huggingface/ConvertBaichuan7BToPmx.py
+++ b/model_zoo/baichuan/huggingface/ConvertBaichuan7BToPmx.py
@@ -69,7 +69,10 @@ def write_pmx_model(model_path, input_base_path):
     hidden_dim = pmx_params_dict['hidden_dim']
     multiple_of = params.get("multiple_of", 256)
     ffn_dim_multiplier = params.get("ffn_dim_multiplier", 1)
-    pmx_params_dict['intermediate_dim'] = compute_intermediate_size(hidden_dim, ffn_dim_multiplier, multiple_of)
+    if "intermediate_size" in params.keys():
+        pmx_params_dict['intermediate_dim'] = params.get("intermediate_size")
+    else:
+        pmx_params_dict['intermediate_dim'] = compute_intermediate_size(hidden_dim, ffn_dim_multiplier, multiple_of)
     write_json(pmx_params_dict, os.path.join(model_path, "pmx_params.json"))
 
     # TO DO: GQA / MQA, only test on llama


### PR DESCRIPTION
When converting baichuan2-13b models by `ConvertBaichuan7BToPmx.py`, an error will occur.

```
Traceback (most recent call last):
  File "ConvertBaichuan7BToPmx.py", line 132, in <module>
    main()
  File "ConvertBaichuan7BToPmx.py", line 126, in main
    write_pmx_model(
  File "ConvertBaichuan7BToPmx.py", line 101, in write_pmx_model
    f"layers.{layer_i}.feed_forward.w2.weight": hf_model_state_dict[f"model.layers.{layer_i}.mlp.down_proj.weight"],
KeyError: 'model.layers.29.mlp.down_proj.weight'
```

The root cause is that the `intermediate_size` is not calculated correctly. Instead we can use the one in `config.json` directly.