### PR TITLE
fix latex equation

### DIFF
--- a/docs/operators/ALiBiMask.md
+++ b/docs/operators/ALiBiMask.md
@@ -8,7 +8,7 @@ that is proportional to their distance.
 ALiBi is defined as:
 
 $$
-\{softmax}\left(\mathbf{q}_i \mathbf{K}^{\top}+m \cdot[-(i-1), \ldots,-2,-1,0]\right)
+softmax\left(\mathbf{q}_i \mathbf{K}^{\top}+m \cdot[-(i-1), \ldots,-2,-1,0]\right)
 $$
 
 ![ALiBi](ALiBi.jpeg)

--- a/docs/operators/ALiBiSlope.md
+++ b/docs/operators/ALiBiSlope.md
@@ -8,7 +8,7 @@ that is proportional to their distance.
 ALiBi is defined as:
 
 $$
-\{softmax}\left(\mathbf{q}_i \mathbf{K}^{\top}+m \cdot[-(i-1), \ldots,-2,-1,0]\right)
+softmax\left(\mathbf{q}_i \mathbf{K}^{\top}+m \cdot[-(i-1), \ldots,-2,-1,0]\right)
 $$
 
 ![ALiBi](ALiBi.jpeg)


### PR DESCRIPTION
`\{softmax}` is not supported in KaTeX, a change to `softmax` can fix it.
![屏幕截图 2024-05-24 135408](https://github.com/openppl-public/ppl.pmx/assets/45957390/2608244f-02fb-497e-a438-7abc324c5f5e)
